### PR TITLE
Allow using a border on RN side as well

### DIFF
--- a/HotBoxService/HotBoxPublisher.h
+++ b/HotBoxService/HotBoxPublisher.h
@@ -9,7 +9,7 @@
 #import <React/RCTView.h>
 
 @interface HotBoxPublisher : RCTView
-@property (nonatomic, assign) CGFloat borderWidth;
+@property (nonatomic, assign) CGFloat talkingBorderWidth;
 @property (nonatomic, assign) BOOL useAlpha;
 @property (nonatomic, assign) CGFloat alphaTimer;
 @property (nonatomic, assign) CGFloat alphaTransition;

--- a/HotBoxService/HotBoxPublisher.m
+++ b/HotBoxService/HotBoxPublisher.m
@@ -10,7 +10,7 @@
 #import <React/RCTViewManager.h>
 
 @interface RCT_EXTERN_MODULE(HotBoxPublisherSwift, RCTViewManager)
-RCT_EXPORT_VIEW_PROPERTY(borderWidth, CGFloat)
+RCT_EXPORT_VIEW_PROPERTY(talkingBorderWidth, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(useAlpha, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(alphaTimer, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(alphaTransition, CGFloat)

--- a/HotBoxService/HotBoxPublisher.swift
+++ b/HotBoxService/HotBoxPublisher.swift
@@ -13,7 +13,7 @@ import OpenTok
 class HotBoxPublisher: UIView {
   
   var publisherView: UIView?
-  var publisherBorderWidth: CGFloat = 2
+  var publisherBorderWidth: CGFloat = 0
   var publisherUseAlpha = false
   var publisherAlphaTimer: CGFloat = 5
   var publisherAlphaTransition: CGFloat = 0.5
@@ -95,8 +95,11 @@ extension HotBoxPublisher: OTPublisherKitAudioLevelDelegate {
       maxVolumeLevel = max(audioLevel, maxVolumeLevel)
       
       let alpha = CGFloat(audioLevel / maxVolumeLevel * 10)
-      layer.borderColor = UIColor.white.withAlphaComponent(alpha).cgColor
-      layer.borderWidth = publisherBorderWidth
+
+      if publisherBorderWidth > 0 {
+        layer.borderColor = UIColor.white.withAlphaComponent(alpha).cgColor
+        layer.borderWidth = publisherBorderWidth
+      }
       
       if publisherUseAlpha && alpha > publisherTalkingAlphaThreshold {
         UIView.animate(withDuration: TimeInterval(publisherAlphaTransition), delay: 0, options: .allowUserInteraction, animations: {

--- a/HotBoxService/HotBoxSubscriber.h
+++ b/HotBoxService/HotBoxSubscriber.h
@@ -10,7 +10,7 @@
 
 @interface HotBoxSubscriber : RCTView
 @property (nonatomic, strong) NSString *streamId;
-@property (nonatomic, assign) CGFloat borderWidth;
+@property (nonatomic, assign) CGFloat talkingBorderWidth;
 @property (nonatomic, assign) BOOL useAlpha;
 @property (nonatomic, assign) CGFloat alphaTimer;
 @property (nonatomic, assign) CGFloat alphaTransition;

--- a/HotBoxService/HotBoxSubscriber.m
+++ b/HotBoxService/HotBoxSubscriber.m
@@ -11,7 +11,7 @@
 
 @interface RCT_EXTERN_MODULE(HotBoxSubscriberSwift, RCTViewManager)
 RCT_EXPORT_VIEW_PROPERTY(streamId, NSString)
-RCT_EXPORT_VIEW_PROPERTY(borderWidth, CGFloat)
+RCT_EXPORT_VIEW_PROPERTY(talkingBorderWidth, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(useAlpha, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(alphaTimer, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(alphaTransition, CGFloat)

--- a/HotBoxService/HotBoxSubscriber.swift
+++ b/HotBoxService/HotBoxSubscriber.swift
@@ -14,7 +14,7 @@ class HotBoxSubscriber: UIView {
   
   var subscriberView: UIView?
   var subscriberStreamId: NSString?
-  var subscriberBorderWidth: CGFloat = 2
+  var subscriberBorderWidth: CGFloat = 0
   var subscriberUseAlpha = false
   var subscriberAlphaTimer: CGFloat = 5
   var subscriberAlphaTransition: CGFloat = 0.5
@@ -91,8 +91,11 @@ extension HotBoxSubscriber: OTSubscriberKitAudioLevelDelegate {
       maxVolumeLevel = max(audioLevel, maxVolumeLevel)
       
       let alpha = CGFloat(audioLevel / maxVolumeLevel * 10)
-      layer.borderColor = UIColor.white.withAlphaComponent(alpha).cgColor
-      layer.borderWidth = subscriberBorderWidth
+
+      if subscriberBorderWidth > 0 {
+        layer.borderColor = UIColor.white.withAlphaComponent(alpha).cgColor
+        layer.borderWidth = subscriberBorderWidth
+      }
       
       if subscriberUseAlpha && alpha > subscriberTalkingAlphaThreshold {
         UIView.animate(withDuration: TimeInterval(subscriberAlphaTransition), delay: 0, options: .allowUserInteraction, animations: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-hot-box",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/src/PublisherView.js
+++ b/src/PublisherView.js
@@ -4,7 +4,7 @@ import  { requireNativeComponent, View } from 'react-native';
 
 class PublisherView extends React.Component {
     static propTypes = {
-        borderWidth: PropTypes.number,
+        talkingBorderWidth: PropTypes.number,
         useAlpha: PropTypes.bool,
         alphaTimer: PropTypes.number,
         alphaTransition: PropTypes.number,

--- a/src/SubscriberView.js
+++ b/src/SubscriberView.js
@@ -5,7 +5,7 @@ import { requireNativeComponent, View } from 'react-native'
 class SubscriberView extends React.Component {
     static propTypes = {
         streamId: PropTypes.string.isRequired,
-        borderWidth: PropTypes.number,
+        talkingBorderWidth: PropTypes.number,
         useAlpha: PropTypes.bool,
         alphaTimer: PropTypes.number,
         alphaTransition: PropTypes.number,


### PR DESCRIPTION
With the current way we couldn't set a `borderWidth` in RN because the prop was over-ridden native side. 

Now we only show a border native side if it's been specified.