### PR TITLE
disconnectAllSessions now works with recent versions of Swift

### DIFF
--- a/HotBoxService/HotBoxService.swift
+++ b/HotBoxService/HotBoxService.swift
@@ -144,7 +144,7 @@ class HotBoxService: RCTEventEmitter {
     }).addDisposableTo(disposeBag)
   }
   
-  @objc func disconnectAllSessions(resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+  @objc func disconnectAllSessions(_ resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     if HotBoxNativeService.shared.disconnectAllSessions() {
       resolve(nil)
     } else {


### PR DESCRIPTION
I don't know much about React Native bridges, so you guys might want to check my work here. I was getting [this error](https://stackoverflow.com/questions/39692230/got-is-not-a-recognized-objective-c-method-when-bridging-swift-to-react-native) when trying to execute `disconnectAllSessions`. Adding the `_` appears to have fixed it.